### PR TITLE
Adds box-shadow CSS exmaples

### DIFF
--- a/docs/live-examples/css-examples/box-shadow.html
+++ b/docs/live-examples/css-examples/box-shadow.html
@@ -1,0 +1,9 @@
+<div id="output">
+  <div id="example-element">
+    <p>This is a box with a box-shadow around it.</p>
+  </div>
+</div>
+
+<p>Try editing the selected example, or select a different example:</p>
+
+<pre class="prettyprint lang-css" id="example-choice-list"><div class=" example-choice">box-shadow: 10px 5px 5px black;</div><div class=" example-choice">box-shadow: 60px -16px teal;</div><div class=" example-choice">box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);</div><div class=" example-choice">box-shadow: inset 5em 1em gold;</div><div class=" example-choice">box-shadow: 3px 3px red, -1em 0 0.4em olive;</div></pre>

--- a/docs/live-examples/css-examples/css/box-shadow.css
+++ b/docs/live-examples/css-examples/css/box-shadow.css
@@ -1,0 +1,7 @@
+#example-element {
+    color: #333;
+    padding: 50px 0;
+    border: 2px solid #333;
+    min-height: 100px;
+    text-align: center;
+}

--- a/docs/pages/css/box-shadow.html
+++ b/docs/pages/css/box-shadow.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../live-examples/css-examples/css/box-shadow.css" />
+    <link rel="stylesheet" href="../../css/css-examples-base.css" />
+  </head>
+  <body>
+    <div id="output">
+  <div id="example-element">
+    <p>This is a box with a box-shadow around it.</p>
+  </div>
+</div>
+
+<p>Try editing the selected example, or select a different example:</p>
+
+<pre class="prettyprint lang-css" id="example-choice-list"><div class=" example-choice">box-shadow: 10px 5px 5px black;</div><div class=" example-choice">box-shadow: 60px -16px teal;</div><div class=" example-choice">box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);</div><div class=" example-choice">box-shadow: inset 5em 1em gold;</div><div class=" example-choice">box-shadow: 3px 3px red, -1em 0 0.4em olive;</div></pre>
+
+    <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+    <script src="../../js/css-examples-base.js"></script>
+  </body>
+</html>

--- a/live-examples/css-examples/box-shadow.html
+++ b/live-examples/css-examples/box-shadow.html
@@ -1,0 +1,9 @@
+<div id="output">
+  <div id="example-element">
+    <p>This is a box with a box-shadow around it.</p>
+  </div>
+</div>
+
+<p>Try editing the selected example, or select a different example:</p>
+
+<pre class="prettyprint lang-css" id="example-choice-list"><div class=" example-choice">box-shadow: 10px 5px 5px black;</div><div class=" example-choice">box-shadow: 60px -16px teal;</div><div class=" example-choice">box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);</div><div class=" example-choice">box-shadow: inset 5em 1em gold;</div><div class=" example-choice">box-shadow: 3px 3px red, -1em 0 0.4em olive;</div></pre>

--- a/live-examples/css-examples/css/box-shadow.css
+++ b/live-examples/css-examples/css/box-shadow.css
@@ -1,0 +1,7 @@
+#example-element {
+    color: #333;
+    padding: 50px 0;
+    border: 2px solid #333;
+    min-height: 100px;
+    text-align: center;
+}

--- a/site.json
+++ b/site.json
@@ -64,6 +64,13 @@
             "fileName": "border-top-color.html",
             "type": "css"
         },
+        "boxShadow": {
+            "baseTmpl": "tmpl/live-css-tmpl.html",
+            "exampleSrc": "../../live-examples/css-examples/css/box-shadow.css",
+            "exampleCode": "live-examples/css-examples/box-shadow.html",
+            "fileName": "box-shadow.html",
+            "type": "css"
+        },
         "filter": {
             "baseTmpl": "tmpl/live-css-tmpl.html",
             "exampleCode": "live-examples/css-examples/filter.html",


### PR DESCRIPTION
@wbamberg @stephaniehobson This adds `box-shadow` live examples but, at the same time demonstrates what a CSS PR would look like.

For this one in particular, you can ignore the files in `docs` as this will be added to `.gitignore` once I have set-up travis to generate the pages on merges to master.

So, had Travis already been set-up, this pull request would consist of:

`live-examples/css-examples/box-shadow.html`
`live-examples/css-examples/css/box-shadow.css`

and the update to `site.json`